### PR TITLE
Fix browser converter for self closing element

### DIFF
--- a/src/__tests__/convert.test.js
+++ b/src/__tests__/convert.test.js
@@ -48,34 +48,44 @@ describe('universal API', () => {
   });
 });
 
+// delete all key property on the given object
+function deleteKey(obj) {
+  delete obj.key;
+
+  if (obj.props && obj.props.children) {
+    obj.props.children.forEach(child => {
+      deleteKey(child);
+    });
+  }
+}
+
+// Compare component object without comparing instance and key
+// key props is not reused in React client rehydration, so we can
+// ignore it
+function jsonc(obj) {
+  const result = JSON.parse(JSON.stringify(obj));
+  deleteKey(result);
+  return result;
+}
+
 function serverBrowserCompare(html, nodeMap, useWrapper) {
-  const htmlServer = convertServer(html);
-  const htmlBrowser = convertBrowser(html);
+  let htmlServer = convertServer(html);
+  let htmlBrowser = convertBrowser(html);
 
   if (useWrapper) {
-    expect(
-      renderer
-        .create(
-          <div>
-            {htmlServer}
-          </div>
-        )
-        .toJSON()
-    ).toEqual(
-      renderer
-        .create(
-          <div>
-            {htmlBrowser}
-          </div>
-        )
-        .toJSON()
+    htmlServer = (
+      <div>
+        {htmlServer}
+      </div>
     );
-    return;
+    htmlBrowser = (
+      <div>
+        {htmlBrowser}
+      </div>
+    );
   }
 
-  expect(renderer.create(htmlServer).toJSON()).toEqual(
-    renderer.create(htmlBrowser).toJSON()
-  );
+  expect(jsonc(htmlBrowser)).toEqual(jsonc(htmlServer));
 }
 
 function suite(converter) {
@@ -90,7 +100,7 @@ function suite(converter) {
   test('self closing component', () => {
     const html = `
       <div>
-        <img src="https://www.google.com/logo.png" />
+        <img src="https://www.google.com/logo.png">
         <iframe src="https://www.youtube.com/embed/I2-_iLzmkVw"></iframe>
       </div>
     `;

--- a/src/server.js
+++ b/src/server.js
@@ -49,10 +49,12 @@ function transform(node: Node, key: string, nodeMap: NodeMap): ?Element {
   const children =
     content === undefined
       ? null
-      : content.map((child, index) => {
-          const childKey = `${key}.${index}`;
-          return transform(child, childKey, nodeMap);
-        });
+      : content
+          .map((child, index) => {
+            const childKey = `${key}.${index}`;
+            return transform(child, childKey, nodeMap);
+          })
+          .filter(child => child !== null);
 
   const Component = nodeMap[tag] || tag;
   return React.createElement(Component, props, children);


### PR DESCRIPTION
Previously in browser by default we always return an empty array for
all components if there's no valid children. Considering empty array
and null mean the same thing for non self-closing component, we can
assume empty children can be represented using null value rather than
empty array that works in all component.

The unit test didn't catch it because of react-test-renderer. Now we
use pure JSON object comparison instead by ignoring component key when
comparing values.

Fix #4