### PR TITLE
Reduce bundle size from 1.5kB to 1.3kB

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -35,7 +35,8 @@ function transform(node, nodeMap: NodeMap, key: ?number) {
     attrs[key] = value;
   }
 
-  const props = Object.assign(mapAttribute(attrs), { key });
+  attrs.key = key;
+  const props = mapAttribute(attrs);
 
   let children = [];
   for (let i = 0; i < node.childNodes.length; i++) {

--- a/src/convertStyle.js
+++ b/src/convertStyle.js
@@ -35,10 +35,10 @@ export default function convertStyle(styleStr: string): Style {
       return declaration !== '';
     })
     .forEach(declaration => {
-      const [property, value] = declaration.split(':');
+      const rules = declaration.split(':');
 
-      const prop = convertProperty(property.trim());
-      const val = convertValue(value.trim());
+      const prop = convertProperty(rules[0].trim());
+      const val = convertValue(rules[1].trim());
       style[prop] = val;
     });
 


### PR DESCRIPTION
Array destructuring is transpiled into `Symbol.iterator` check with `try/catch/throw` statement which is unnecessary and bloat our bundle without any benefit.

See:
![image](https://user-images.githubusercontent.com/1614415/29280546-dcc32e0e-8145-11e7-9e05-bc0ad8d7de82.png)