### PR TITLE
Support more svg attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,7 @@ class Component extends React.Component {
 ```
 
 ## Trade Off
- - Some SVG attributes are not supported due to attribute mapping contributes to big bundle size
- - Inline event attribute (on-xxx="") are not supported due to unnecessary complexity
+Inline event attributes (`onclick=""` etc) are not supported due to unnecessary complexity
 
 ## License
 

--- a/src/__tests__/mapAttribute.test.js
+++ b/src/__tests__/mapAttribute.test.js
@@ -11,6 +11,15 @@ test('copy safe attributes', () => {
   expect(mapAttribute(attribute)).toEqual(attribute);
 });
 
+test('do not change data-* and aria-* attribute', () => {
+  const attribute = {
+    'data-type': 'calendar',
+    'aria-describedby': 'info',
+  };
+
+  expect(mapAttribute(attribute)).toEqual(attribute);
+});
+
 test("convert 'unsafe' attributes", () => {
   const attribute = {
     class: 'col-md-4',

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -1,0 +1,15 @@
+/* eslint-env jest */
+import { hypenColonToCamelCase as convert } from '../utils';
+
+test('convert hypen to camel case', () => {
+  expect(convert('margin-top')).toEqual('marginTop');
+  expect(convert('fill-rule')).toEqual('fillRule');
+  expect(convert('color-interpolation-filters')).toEqual(
+    'colorInterpolationFilters'
+  );
+});
+
+test('convert colon to camel case', () => {
+  expect(convert('xlink:actuate')).toEqual('xlinkActuate');
+  expect(convert('xml:lang')).toEqual('xmlLang');
+});

--- a/src/convertStyle.js
+++ b/src/convertStyle.js
@@ -1,5 +1,7 @@
 // @flow
 // Based on https://github.com/reactjs/react-magic/blob/master/src/htmltojsx.js
+import { hypenColonToCamelCase } from './utils';
+
 export type Style = {
   [key: string]: number | string,
 };
@@ -10,10 +12,7 @@ function convertProperty(prop: string): string {
     prop = prop.substr(1);
   }
 
-  // convert hypen to camel case
-  return prop.replace(/-(.)/g, (match, chr) => {
-    return chr.toUpperCase();
-  });
+  return hypenColonToCamelCase(prop);
 }
 
 function convertValue(value: string): number | string {

--- a/src/mapAttribute.js
+++ b/src/mapAttribute.js
@@ -1,12 +1,13 @@
 // @flow
 /* global preval */
 import convertStyle from './convertStyle';
+import { hypenColonToCamelCase } from './utils';
 
 type Attributes = {
   [key: string]: string,
 };
 
-// only includes attribute that needs mapping
+// only includes attribute that needs mapping (lowercase -> camelCase)
 // credits: https://github.com/noraesae/react-attr-converter/blob/master/index.js
 const attributeMap: Object = preval`
   const map = JSON.parse(
@@ -34,17 +35,25 @@ const attributeMap: Object = preval`
 // convert attr to valid react props
 export default function mapAttribute(attrs: Attributes = {}) {
   return Object.keys(attrs).reduce((result, attr) => {
-    // ignore event attribute
+    // ignore inline event attribute
     if (/^on.*/.test(attr)) {
       return result;
     }
 
-    const name = attributeMap[attr] || attr;
-    if (name === 'style') {
-      result[name] = convertStyle(attrs[attr]);
-    } else {
-      result[name] = attrs[attr];
+    // Convert attribute to camelCase except data-* and aria-* attribute
+    // https://facebook.github.io/react/docs/dom-elements.html
+    let attributeName = attr;
+    if (!/^(data|aria)-/.test(attr)) {
+      attributeName = hypenColonToCamelCase(attr);
     }
+
+    const name = attributeMap[attributeName] || attributeName;
+    if (name === 'style') {
+      result[name] = convertStyle(attrs[attributeName]);
+    } else {
+      result[name] = attrs[attributeName];
+    }
+
     return result;
   }, {});
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,8 @@
+export function hypenColonToCamelCase(str) {
+  // convert hypen and colon to camel case
+  // color-profile -> colorProfile
+  // xlink:role -> xlinkRole
+  return str.replace(/(-|:)(.)/g, (match, symbol, char) => {
+    return char.toUpperCase();
+  });
+}


### PR DESCRIPTION
Some svg attributes are separated by hypen or colon, which makes it easy to convert using regexp without having to dump all attribute mapping which is huge