### PR TITLE
fix unescaped html entities in browser converter

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "posthtml-parser": "^0.2.1"
   },
   "peerDependencies": {
-    "react": "^15.6.1"
+    "react": "^15.6.1 || ^16.0.0"
   },
   "devDependencies": {
     "babel-plugin-preval": "^1.4.3",
@@ -61,8 +61,8 @@
     "lint-staged": "^4.0.3",
     "npm-run-all": "^4.0.2",
     "prettier": "^1.5.3",
-    "react": "^15.6.1",
-    "react-test-renderer": "^15.6.1",
+    "react": "^16.0.0",
+    "react-test-renderer": "^16.0.0",
     "rimraf": "^2.6.1",
     "rollup": "^0.47.2",
     "rollup-plugin-babel": "^3.0.1",

--- a/src/__tests__/convert.test.js
+++ b/src/__tests__/convert.test.js
@@ -10,6 +10,14 @@ describe('server', () => {
 
 describe('browser', () => {
   suite(convertBrowser);
+
+  // This is special test case for browser because in browser
+  // we should use unescaped html entities.
+  test('unescape html entities', () => {
+    const encoded = convertBrowser('<div>one &amp; two with <script></div>');
+    const decoded = convertBrowser('<div>one & two with <script></div>');
+    expect(encoded).toEqual(decoded);
+  });
 });
 
 describe('universal API', () => {

--- a/src/browser.js
+++ b/src/browser.js
@@ -12,16 +12,19 @@ const NodeTypes = {
 };
 
 const tempEl = document.createElement('div');
-function escape(str) {
-  tempEl.textContent = str;
-  return tempEl.innerHTML;
+function unescape(str) {
+  // Here we use innerHTML to unescape html entities.
+  // This is okay because we use the returned value as react children
+  // not dangerouslySetInnerHTML
+  tempEl.innerHTML = str;
+  return tempEl.textContent;
 }
 
 function transform(node, nodeMap: NodeMap, key: ?number) {
   if (node.nodeType === NodeTypes.COMMENT) {
     return null;
   } else if (node.nodeType === NodeTypes.TEXT) {
-    return node.textContent.trim() === '' ? null : escape(node.textContent);
+    return node.textContent.trim() === '' ? null : unescape(node.textContent);
   }
 
   // element

--- a/yarn.lock
+++ b/yarn.lock
@@ -953,14 +953,6 @@ cosmiconfig@^1.1.0:
     pinkie-promise "^2.0.0"
     require-from-string "^1.1.0"
 
-create-react-class@^15.6.0:
-  version "15.6.0"
-  resolved "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz#ab448497c26566e1e29413e883207d57cfe7bed4"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -1237,9 +1229,9 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.9:
-  version "0.8.14"
-  resolved "https://registry.npmjs.org/fbjs/-/fbjs-0.8.14.tgz#d1dbe2be254c35a91e09f31f9cd50a40b2a0ed1c"
+fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -2552,12 +2544,13 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10:
-  version "15.5.10"
-  resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+prop-types@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
-    fbjs "^0.8.9"
+    fbjs "^0.8.16"
     loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 prr@~0.0.0:
   version "0.0.0"
@@ -2588,22 +2581,21 @@ randomatic@^1.1.3:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-react-test-renderer@^15.6.1:
-  version "15.6.1"
-  resolved "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-15.6.1.tgz#026f4a5bb5552661fd2cc4bbcd0d4bc8a35ebf7e"
+react-test-renderer@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.0.0.tgz#9fe7b8308f2f71f29fc356d4102086f131c9cb15"
   dependencies:
-    fbjs "^0.8.9"
-    object-assign "^4.1.0"
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
 
-react@^15.6.1:
-  version "15.6.1"
-  resolved "https://registry.npmjs.org/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"
+react@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.npmjs.org/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
   dependencies:
-    create-react-class "^15.6.0"
-    fbjs "^0.8.9"
+    fbjs "^0.8.16"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Unescape html entities in browser doesn't support rendering encoded html entities in client side

Close #10 