### PR TITLE
Add ES modules for modern bundlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 lib/index.js
+lib/module.js
 lib/htmr.min.js
 coverage/
 *.log

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "htmr",
   "version": "0.4.10",
-  "description": "Simple and lightweight (< 2kB) HTML to React converter that works in server and browser",
+  "description":
+    "Simple and lightweight (< 2kB) HTML to React converter that works in server and browser",
   "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "module": "lib/module.js",
   "browser": "lib/htmr.min.js",
+  "files": ["lib"],
   "scripts": {
     "build": "rollup -c",
     "clean": "rimraf lib",
@@ -84,9 +84,6 @@
     }
   ],
   "lint-staged": {
-    "*.{js,md}": [
-      "prettier --write",
-      "git add"
-    ]
+    "*.{js,md}": ["prettier --write", "git add"]
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,48 +1,45 @@
-import babel from 'rollup-plugin-babel';
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
+import babel from 'rollup-plugin-babel';
 import uglify from 'rollup-plugin-uglify';
 
 export default [
-  // cjs
-  {
-    input: 'src/server.js',
-    output: {
-      file: 'lib/index.js',
-      format: 'cjs',
-    },
-    plugins: [
-      babel({
-        exclude: 'node_modules/**',
-      }),
-    ],
-    external: ['posthtml-parser', 'react', 'html-entities'],
-  },
-  // umd
+  // browser-friendly UMD build
   {
     input: 'src/browser.js',
+    external: ['react'],
     output: {
+      name: 'htmr',
       file: 'lib/htmr.min.js',
       format: 'umd',
-      globals: {
-        react: 'React',
-      },
     },
     plugins: [
-      resolve({
-        jsnext: false,
-        main: true,
-        browser: true,
-      }),
-      commonjs({
-        ignoreGlobal: true,
-        include: 'node_modules/**',
-      }),
+      babel({ exclude: 'node_modules/**' }),
+      commonjs({ include: 'node_modules/**' }),
+      resolve(),
+      uglify(),
+    ],
+  },
+  // commonJS
+  {
+    input: 'src/server.js',
+    external: ['posthtml-parser', 'react', 'html-entities'],
+    output: [{ file: 'lib/index.js', format: 'cjs' }],
+    plugins: [
       babel({
         exclude: 'node_modules/**',
       }),
-      uglify(),
     ],
+  },
+  //   ES modules
+  {
+    input: 'src/browser.js',
     external: ['react'],
+    output: [{ file: 'lib/module.js', format: 'es' }],
+    plugins: [
+      babel({
+        exclude: 'node_modules/**',
+      }),
+    ],
   },
 ];

--- a/src/browser.js
+++ b/src/browser.js
@@ -89,4 +89,4 @@ function convertBrowser(
   return result;
 }
 
-module.exports = convertBrowser;
+export default convertBrowser;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3505,9 +3505,9 @@ rollup-pluginutils@^2.0.1:
     estree-walker "^0.3.0"
     micromatch "^2.3.11"
 
-rollup@^0.53.4:
-  version "0.53.4"
-  resolved "https://registry.npmjs.org/rollup/-/rollup-0.53.4.tgz#f92ce56ee1d097ad5b6f13951bc80db5fef18113"
+rollup@^0.54.0:
+  version "0.54.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.54.0.tgz#0641b8154ba02706464285d2ead924c486b48ba9"
 
 run-async@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
This is a fantastic library. The small size and single purpose were exactly what I was looking for.

I ran into a breaking bug when building for production with webpack 3, as uglify has trouble with mixed `import` and `module.exports` (expecting `export default`). 

I rewrote the rollup config to use a newer syntax and added an ES module export. That export was also added to `.gitignore` and `package.json` under the `module` property so it can be resolved by webpack.

The tests all passed and the minified browser bundle does not return the export, just a function now.