### PR TITLE
Don't remove whitespace-only text nodes

### DIFF
--- a/src/__tests__/__snapshots__/convert.test.js.snap
+++ b/src/__tests__/__snapshots__/convert.test.js.snap
@@ -116,6 +116,19 @@ exports[`multi children 1`] = `
 </div>
 `;
 
+exports[`newline between tags 1`] = `
+<pre>
+  <span>
+    Hello
+  </span>
+  
+
+  <span>
+    World
+  </span>
+</pre>
+`;
+
 exports[`preserve child of style tag 1`] = `
 <style
   dangerouslySetInnerHTML={
@@ -189,4 +202,16 @@ exports[`unsafe html attributes 1`] = `
   className="input-text"
   htmlFor="name"
 />
+`;
+
+exports[`whitespace only text nodes 1`] = `
+Array [
+  <span>
+    Hello
+  </span>,
+  " ",
+  <span>
+    World
+  </span>,
+]
 `;

--- a/src/__tests__/convert.test.js
+++ b/src/__tests__/convert.test.js
@@ -11,14 +11,14 @@ testRender('convert correctly', () => {
 });
 
 testRender('supports valid html attribute', () => {
-  const html = `
-    <div data-type="calendar" aria-describedby="info">
-      <link xml:lang="en" xlink:actuate="" />
-      <svg fill-rule="evenodd" color-interpolation-filters="">
-        <path fill="#fa0"></path>
-      </svg>
-    </div>
-  `;
+  const html = [
+    '<div data-type="calendar" aria-describedby="info">',
+    '<link xml:lang="en" xlink:actuate="" />',
+    '<svg fill-rule="evenodd" color-interpolation-filters="">',
+    '<path fill="#fa0"></path>',
+    '</svg>',
+    '</div>',
+  ].join('');
 
   return { html };
 });
@@ -29,21 +29,18 @@ testRender('unsafe html attributes', () => {
 });
 
 testRender('self closing component', () => {
-  const html = `
-    <div>
-      <img src="https://www.google.com/logo.png" />
-      <iframe src="https://www.youtube.com/embed/I2-_iLzmkVw"></iframe>
-    </div>
-  `;
+  const html = [
+    '<div>',
+    '<img src="https://www.google.com/logo.png" />',
+    '<iframe src="https://www.youtube.com/embed/I2-_iLzmkVw"></iframe>',
+    '</div>',
+  ].join('');
 
   return { html };
 });
 
 testRender('multi children', () => {
-  const html = `
-    <p>Multi</p>
-    <p>Component</p>
-  `;
+  const html = '<p>Multi</p><p>Component</p>';
 
   return { html, multi: true };
 });
@@ -54,11 +51,11 @@ testRender('element inside text node', () => {
 });
 
 testRender('convert style values', () => {
-  const html = `
-    <div style="margin: 0 auto; padding: 0 10px">
-      <span style="font-size: 12"></span>
-    </div>
-  `;
+  const html = [
+    '<div style="margin: 0 auto; padding: 0 10px">',
+    '<span style="font-size: 12"></span>',
+    '</div>',
+  ].join('');
 
   return { html };
 });
@@ -74,10 +71,8 @@ testRender('css vendor prefixes', () => {
 });
 
 testRender('css html entities', () => {
-  const html = `
-    <div style="font-family: Consolas, &quot;Liberation Mono &quot;">
-    </div>
-  `;
+  const html =
+    '<div style="font-family: Consolas, &quot;Liberation Mono &quot;"></div>';
 
   return { html };
 });
@@ -95,9 +90,8 @@ testRender('ignore partially invalid style', () => {
 });
 
 testRender('style with url & protocol', () => {
-  const html = `
-    <div class="tera-promo-card--header" style="background-image:url(https://d1nabgopwop1kh.cloudfront.net/xx);"></div>
-  `;
+  const html =
+    '<div class="tera-promo-card--header" style="background-image:url(https://d1nabgopwop1kh.cloudfront.net/xx);"></div>';
 
   return { html };
 });
@@ -124,19 +118,16 @@ testRender('unescape html entities', () => {
 });
 
 testRender('ignore comment', () => {
-  const html = `
-    <!-- comment should be ignored-->
-    <div>no comment</div>
-  `;
+  const html = '<!-- comment should be ignored--><div>no comment</div>';
 
   return { html };
 });
 
 testRender('ignore multiline html comment', () => {
-  const html = `
-    <!--<div>\n<p>multiline</p> \t</div>-->
-    <div>no multiline comment</div>
-  `;
+  const html = [
+    '<!--<div>\n<p>multiline</p> \t</div>-->',
+    '<div>no multiline comment</div>',
+  ].join('');
 
   return { html };
 });
@@ -151,6 +142,16 @@ testRender('custom component', () => {
   );
 
   return { html, map: { p: Paragraph } };
+});
+
+testRender('whitespace only text nodes', () => {
+  const html = '<span>Hello</span> <span>World</span>';
+  return { html };
+});
+
+testRender('newline between tags', () => {
+  const html = '<pre><span>Hello</span>\n<span>World</span></pre>';
+  return { html };
 });
 
 /**

--- a/src/browser.js
+++ b/src/browser.js
@@ -24,7 +24,9 @@ function transform(node, nodeMap: NodeMap, key: ?number) {
   if (node.nodeType === NodeTypes.COMMENT) {
     return null;
   } else if (node.nodeType === NodeTypes.TEXT) {
-    return node.textContent.trim() === '' ? null : unescape(node.textContent);
+    return node.textContent.trim() === ''
+      ? node.textContent
+      : unescape(node.textContent);
   }
 
   // element

--- a/src/server.js
+++ b/src/server.js
@@ -26,8 +26,11 @@ function transform(node: Node, key: string, nodeMap: NodeMap): ?Element {
     // newline and space will be parsed as 'node' in posthtml-parser,
     // we can ignore it along with comment node
     const text = node.trim();
-    if (text === '' || /^<!--[\s\S]+-->/.test(text)) {
+    if (/^<!--[\s\S]+-->/.test(text)) {
       return null;
+    }
+    if (text === '') {
+      return node;
     }
 
     return HtmlEntity.decode(node);


### PR DESCRIPTION
This PR fixes the issue described in #22. @pveyes: Regarding your suggestion:

> Remove the whitespace caused by template literal for existing test (so the existing snapshot doesn't need to change)

I'm not sure what is the best way to accomplish this. The simplest way I could think of to avoid snapshots from changing was to concatenate arrays of strings.