### PR TITLE
Also remove whitespace from thead and tfoot but not th and td

### DIFF
--- a/src/__tests__/__snapshots__/convert.test.js.snap
+++ b/src/__tests__/__snapshots__/convert.test.js.snap
@@ -182,12 +182,12 @@ exports[`remove whitespace on table 1`] = `
   <tbody>
     <tr>
       <th>
-        title
+         title
       </th>
     </tr>
     <tr>
       <td>
-        entry
+        entry 
       </td>
     </tr>
   </tbody>

--- a/src/__tests__/convert.test.js
+++ b/src/__tests__/convert.test.js
@@ -194,10 +194,10 @@ test('remove whitespace on table', () => {
     <table>
       <tbody>
         <tr>
-          <th>title</th>
+          <th> title</th>
         </tr>
         <tr>
-          <td>entry</td>
+          <td>entry </td>
         </tr>
       </tbody>
     </table>

--- a/src/browser.js
+++ b/src/browser.js
@@ -11,7 +11,7 @@ const NodeTypes = {
   COMMENT: 8,
 };
 
-const TABLE_ELEMENTS = ['table', 'tbody', 'td', 'th', 'tr'];
+const TABLE_ELEMENTS = ['table', 'tbody', 'thead', 'tfoot', 'tr'];
 
 const tempEl = document.createElement('div');
 function unescape(str) {

--- a/src/server.js
+++ b/src/server.js
@@ -21,7 +21,7 @@ type ElementNode = {
 
 type Element = React$Element<*> | string;
 
-const TABLE_ELEMENTS = ['table', 'tbody', 'td', 'th', 'tr'];
+const TABLE_ELEMENTS = ['table', 'tbody', 'thead', 'tfoot', 'tr'];
 
 function transform(node: Node, key: string, options: HtmrOptions): ?Element {
   const defaultMap = options.map._;


### PR DESCRIPTION
I noticed you fixed the warnings related to whitespace inside tables. Thank you 🙌 

I still have however a warning for whitespace in `<thead>` and it seems the same happens for `<tfoot>`:

> Warning: validateDOMNesting(...): Whitespace text nodes cannot appear as a child of &lt;thead>. Make sure you don't have any extra whitespace between tags on each line of your source code.

On the other hand, whitespace inside `<td>` and `<th>` is safe and doesn't trigger any warnings (at least in React v16). So this PR simply updates the `TABLE_ELEMENTS` list. Let me know if you disagree!
