### PR TITLE
add dangerouslySetChildren

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ class Component extends React.Component {
 }
 ```
 
-The API also accepts second argument `options` containing few optional fields:
+The API also accepts second argument `options` containing few optional fields. Below are their default values:
 
 ```js
 const options = {
   transform: {},
   preserveAttributes: [],
+  dangerouslySetChildren: ['style'],
 };
 convert(html, options);
 ```
@@ -114,6 +115,16 @@ For example you want to make sure `ng-if`, `v-if` and `v-for` to be rendered as 
 convert(html, { preserveAttributes: ['ng-if', new RegExp('v-')] });
 ```
 
+### dangerouslySetChildren
+
+By default `htmr` will only render children of `style` tag inside `dangerouslySetInnerHTML` due to security reason. You can override this behavior by passing array of HTML tags if you want the children of the tag to be rendered dangerously.
+
+```js
+convert(html, { dangerouslySetChildren: ['code', 'style'] });
+```
+
+**Note** that if you still want `style` tag to be rendered using `dangerouslySetInnerHTML`, you still need to include it in the array.
+
 ## Multiple children
 
 You can also convert HTML string which contains multiple elements. This returns
@@ -157,8 +168,8 @@ using this library, you can check out some related projects below.
 
 * Inline event attributes (`onclick=""` etc) are not supported due to unnecessary complexity
 * htmr use native browser HTML parser when run in browser instead of using custom parser. Due to how browser HTML parser works, you can get weird result if you supply "invalid" html, for example `div` inside `p` element like `<p><div>text</div></p>`
-* Script tag is not rendered using `dangerouslySetInnerHTML` by default due to security. You can opt in by using [custom component mapping](#custom-component)
-* Style tag renders it children using `dangerouslySetInnerHTML` by default. You can also reverse this behavior using custom mapping.
+* Script tag is not rendered using `dangerouslySetInnerHTML` by default due to security. You can opt in by using [`dangerouslySetChildren`](#dangerouslysetchildren)
+* Style tag renders it children using `dangerouslySetInnerHTML` by default. You can also reverse this behavior using same method.
 
 ## Related projects
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -73,6 +73,11 @@ function transform(node: any, key: string, options: HtmrOptions): ChildComponent
     return React.createElement(tag, props, null);
   }
 
+  if(options.dangerouslySetChildren.indexOf(tag) !== -1){
+    props.dangerouslySetInnerHTML = { __html: node.innerHTML.replace(/"/g, "&quot;") };
+    return React.createElement(tag, props, null);
+  }
+
   // self closing tag shouldn't have children
   const reactChildren = children.length === 0
     ? null
@@ -97,9 +102,10 @@ function convertBrowser(
     throw new TypeError('Expected HTML string');
   }
 
-  const opts = {
+  const opts: HtmrOptions = {
     transform: options.transform || {},
     preserveAttributes: options.preserveAttributes || [],
+    dangerouslySetChildren: options.dangerouslySetChildren || []
   };
   const container = document.createElement('div');
   container.innerHTML = html.trim();

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -67,14 +67,8 @@ function transform(node: any, key: string, options: HtmrOptions): ChildComponent
     }
   }
 
-  // style tag needs to preserve its children
-  if (tag === 'style' && !customElement && !defaultTransform) {
-    props.dangerouslySetInnerHTML = { __html: node.textContent };
-    return React.createElement(tag, props, null);
-  }
-
-  if(options.dangerouslySetChildren.indexOf(tag) !== -1){
-    props.dangerouslySetInnerHTML = { __html: node.innerHTML.replace(/"/g, "&quot;") };
+  if (options.dangerouslySetChildren.indexOf(tag) > -1) {
+    props.dangerouslySetInnerHTML = { __html: node.innerHTML };
     return React.createElement(tag, props, null);
   }
 
@@ -105,7 +99,7 @@ function convertBrowser(
   const opts: HtmrOptions = {
     transform: options.transform || {},
     preserveAttributes: options.preserveAttributes || [],
-    dangerouslySetChildren: options.dangerouslySetChildren || []
+    dangerouslySetChildren: options.dangerouslySetChildren || ["style"]
   };
   const container = document.createElement('div');
   container.innerHTML = html.trim();

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -68,7 +68,12 @@ function transform(node: any, key: string, options: HtmrOptions): ChildComponent
   }
 
   if (options.dangerouslySetChildren.indexOf(tag) > -1) {
-    props.dangerouslySetInnerHTML = { __html: node.innerHTML };
+    let html = node.innerHTML;
+    // we need to preserve quote inside style declaration
+    if (tag !== 'style') {
+      html = html.replace(/"/g, "&quot;")
+    }
+    props.dangerouslySetInnerHTML = { __html: html.trim() };
     return React.createElement(tag, props, null);
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -54,15 +54,13 @@ function transform(node: Node, key: string, options: HtmrOptions): ChildComponen
     { key }
   );
 
-  // style tag needs to preserve its children
-  if (tag === 'style' && !customElement && !defaultTransform) {
-    props.dangerouslySetInnerHTML = { __html: <string>content[0] };
-    return React.createElement(tag, props, null);
-  }
-
   // if the tags children should be set dangerously
-  if(options.dangerouslySetChildren.indexOf(tag) !== -1){
-    props.dangerouslySetInnerHTML = { __html: <string>content[0] };
+  if (options.dangerouslySetChildren.indexOf(tag) > -1) {
+    const innerHTML = <TextNode>content[0];
+    props.dangerouslySetInnerHTML = {
+      // decode &quot; to make sure browser & server render the same thing 
+      __html: innerHTML.replace(/&quot;/g, "\"")
+    };
     return React.createElement(tag, props, null);
   }
 
@@ -107,7 +105,7 @@ export default function convertServer(html: string, options: Partial<HtmrOptions
   const opts: HtmrOptions = {
     transform: options.transform || {},
     preserveAttributes: options.preserveAttributes || [],
-    dangerouslySetChildren: options.dangerouslySetChildren || [],
+    dangerouslySetChildren: options.dangerouslySetChildren || ["style"],
   };
   const ast: Array<Node> = parse(html.trim());
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -58,8 +58,7 @@ function transform(node: Node, key: string, options: HtmrOptions): ChildComponen
   if (options.dangerouslySetChildren.indexOf(tag) > -1) {
     const innerHTML = <TextNode>content[0];
     props.dangerouslySetInnerHTML = {
-      // decode &quot; to make sure browser & server render the same thing 
-      __html: innerHTML.replace(/&quot;/g, "\"")
+      __html: innerHTML.trim()
     };
     return React.createElement(tag, props, null);
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -60,6 +60,12 @@ function transform(node: Node, key: string, options: HtmrOptions): ChildComponen
     return React.createElement(tag, props, null);
   }
 
+  // if the tags children should be set dangerously
+  if(options.dangerouslySetChildren.indexOf(tag) !== -1){
+    props.dangerouslySetInnerHTML = { __html: <string>content[0] };
+    return React.createElement(tag, props, null);
+  }
+
   // self closing component doesn't have children
   let children =
     content === undefined
@@ -98,9 +104,10 @@ export default function convertServer(html: string, options: Partial<HtmrOptions
     throw new TypeError('Expected HTML string');
   }
 
-  const opts = {
+  const opts: HtmrOptions = {
     transform: options.transform || {},
     preserveAttributes: options.preserveAttributes || [],
+    dangerouslySetChildren: options.dangerouslySetChildren || [],
   };
   const ast: Array<Node> = parse(html.trim());
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,8 @@ type DefaultTransform = {
 export type HtmrOptions = {
   transform: Partial<HTMLTransform & DefaultTransform>,
   preserveAttributes: Array<String | RegExp>,
+  /** An array of tags whos children should be set as raw html */
+  dangerouslySetChildren: string[]
 };
 
 type Component = ReactElement<any>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,7 @@ export type HtmrOptions = {
   transform: Partial<HTMLTransform & DefaultTransform>,
   preserveAttributes: Array<String | RegExp>,
   /** An array of tags whos children should be set as raw html */
-  dangerouslySetChildren: string[]
+  dangerouslySetChildren: HTMLTags[]
 };
 
 type Component = ReactElement<any>;

--- a/test/__snapshots__/convert.test.js.snap
+++ b/test/__snapshots__/convert.test.js.snap
@@ -224,7 +224,7 @@ exports[`should dangerously set html for required tags 1`] = `
 <pre
   dangerouslySetInnerHTML={
     Object {
-      "__html": "&lt;a href=&quot;/&quot;&gt;Test&lt;/a&gt;",
+      "__html": "&lt;a href=\\"/\\"&gt;Test&lt;/a&gt;",
     }
   }
 />

--- a/test/__snapshots__/convert.test.js.snap
+++ b/test/__snapshots__/convert.test.js.snap
@@ -220,6 +220,16 @@ exports[`self closing component 1`] = `
 </div>
 `;
 
+exports[`should dangerously set html for required tags 1`] = `
+<pre
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "&lt;a href=&quot;/&quot;&gt;Test&lt;/a&gt;",
+    }
+  }
+/>
+`;
+
 exports[`style with url & protocol 1`] = `
 <div
   className="tera-promo-card--header"

--- a/test/__snapshots__/convert.test.js.snap
+++ b/test/__snapshots__/convert.test.js.snap
@@ -178,15 +178,13 @@ exports[`preserve child of style tag 1`] = `
 <style
   dangerouslySetInnerHTML={
     Object {
-      "__html": "
-      ul > li {
+      "__html": "ul > li {
         list-style: none
       }
 
       div[data-id=\\"test\\"]:not(.y) {
         display: none;
-      }
-    ",
+      }",
     }
   }
 />
@@ -224,7 +222,7 @@ exports[`should dangerously set html for required tags 1`] = `
 <pre
   dangerouslySetInnerHTML={
     Object {
-      "__html": "&lt;a href=\\"/\\"&gt;Test&lt;/a&gt;",
+      "__html": "&lt;a href=&quot;/&quot;&gt;Test&lt;/a&gt;",
     }
   }
 />

--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -230,6 +230,12 @@ test('allow preserve some attributes', () => {
   testRender(html, { preserveAttributes: ['ng-if', new RegExp('tv-')] });
 });
 
+test('should dangerously set html for required tags', () => {
+  const html = `<pre>&lt;a href=&quot;/&quot;&gt;Test&lt;/a&gt;</pre>`;
+
+  testRender(html, { dangerouslySetChildren: ['pre'] });
+});
+
 expect.extend({
   toRenderConsistently({ server, browser }, html) {
     const serverRender = renderer.create(server);

--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -231,7 +231,11 @@ test('allow preserve some attributes', () => {
 });
 
 test('should dangerously set html for required tags', () => {
-  const html = `<pre>&lt;a href=&quot;/&quot;&gt;Test&lt;/a&gt;</pre>`;
+  const html = `
+    <pre>
+      &lt;a href=&quot;/&quot;&gt;Test&lt;/a&gt;
+    </pre>
+  `;
 
   testRender(html, { dangerouslySetChildren: ['pre'] });
 });


### PR DESCRIPTION
I was having an issue with `<code>` tags and the content being parsed differently between the browser and the server.

It seemed to be that `<code>&lt;a href=&quot;/&quot;&gt;Test&lt;/a&gt;</code>`  was becoming `<code>Test</code>` after being passed through htmr.

Weirdly this seemed to be an issue in the browser renderer not the server. When I added the failing test the output was only broken on the browser.

With this PR there is now an option of `dangerouslySetChildren` which you pass an array of tags to. If a tag is present in the list its children are passed to `dangerouslySetInnerHTML` instead of being parsed.