### PR TITLE
Mark options parameter optional in TypeScript type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
 import { HtmrOptions } from './src/types';
 import { ReactNode } from 'react';
 
-export default function htmr(html: string, options: Partial<HtmrOptions>): ReactNode
+export default function htmr(html: string, options?: Partial<HtmrOptions>): ReactNode


### PR DESCRIPTION
Since the options parameter is initialized with an empty object literal in `browser.ts` the type definition of the `convert` method is incorrect in my opinion. This parameter should be marked as optional, since it is not mandatory. Right now TypeScript is showing an error, when not passing an empty object to the `convert` method (see the screenshot).

```js
// browser.ts
function convertBrowser(
  html: string,
  options: Partial<HtmrOptions> = {}
) { ... }
```

![image](https://user-images.githubusercontent.com/3109364/60445901-7eb21f80-9c20-11e9-925c-586e93d07fb3.png)
