### PR TITLE
feat: Better typescript support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   bundle-check:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
 
     steps:
@@ -24,6 +25,7 @@ jobs:
           yarn test:size
 
   test:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,6 @@
-import { HtmrOptions } from './src/types';
+import { HtmrOptions as Options } from './src/types';
 import { ReactNode } from 'react';
 
-export default function htmr(html: string, options?: Partial<HtmrOptions>): ReactNode
+export default function htmr(html: string, options?: Partial<Options>): ReactNode
+
+export type HtmrOptions = Partial<Options>

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -66,7 +66,7 @@ function transform(node: any, key: string, options: HtmrOptions): ReactNode {
     }
     props.dangerouslySetInnerHTML = { __html: html.trim() };
     return customElement
-      ? React.createElement(customElement, props, null)
+      ? React.createElement(customElement as any, props, null)
       : defaultTransform
         ? defaultTransform(tag, props, null)
         : React.createElement(tag, props, null)
@@ -78,7 +78,7 @@ function transform(node: any, key: string, options: HtmrOptions): ReactNode {
     : children;
 
   if (customElement) {
-    return React.createElement(customElement, props, reactChildren);
+    return React.createElement(customElement as any, props, reactChildren);
   }
 
   if (defaultTransform) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -53,7 +53,7 @@ function transform(node: Node, key: string, options: HtmrOptions): ReactNode {
           __html: childNode.data.trim()
         };
         return customElement
-          ? React.createElement(customElement, props, null)
+          ? React.createElement(customElement as any, props, null)
           : defaultTransform
             ? defaultTransform(name, props, null)
             : React.createElement(name, props, null)
@@ -69,7 +69,7 @@ function transform(node: Node, key: string, options: HtmrOptions): ReactNode {
         : childNodes;
 
       if (customElement) {
-        return React.createElement(customElement, props, children);
+        return React.createElement(customElement as any, props, children);
       }
 
       if (defaultTransform) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,13 +1,14 @@
-import { ReactElement, ReactHTML, ReactNode, ComponentType } from "react";
+import React, { ReactHTML, ReactSVG, ReactNode, ComponentType } from "react";
 
 export type HTMLTags = keyof ReactHTML;
+export type SVGTags = keyof ReactSVG;
 
 type HTMLTransform = {
-  [tag in HTMLTags]: HTMLTags | ComponentType;
+  [tag in HTMLTags | SVGTags]: HTMLTags | SVGTags | ComponentType<React.ComponentProps<tag>>;
 };
 
 type DefaultTransform = {
-  _: <T>(element: string | HTMLTags, props?: T, children?: ReactNode) => ReactElement<T>
+  _: <P>(element: string | HTMLTags | SVGTags, props?: P, children?: ReactNode) => ReactNode
 }
 
 export type HtmrOptions = {


### PR DESCRIPTION
- exported `HtmrOptions` as top-level named export

```ts
import { HtmrOptions } from 'htmr'
```

 - Better props type annotation for transform

```ts
const transform: HtmrOptions = {
  a: props => {
    // props is now automatically inferred
    if (props.href.startsWith('http') {
    }
  }
}
```

- SVG tags support

```ts
const transform: HtmrOptions = {
  svg: props => {
    return <>{props.viewBox}</>
  }
}
```

- Fixed type definition for default transform return value
- Adjust README for type limitation for custom elements