### PR TITLE
Handle dangerouslySetChildren for empty script tag

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -60,11 +60,16 @@ function transform(node: any, key: string, options: HtmrOptions): ReactNode {
 
   if (options.dangerouslySetChildren.indexOf(tag) > -1) {
     let html = node.innerHTML;
-    // we need to preserve quote inside style declaration
-    if (tag !== 'style') {
-      html = html.replace(/"/g, "&quot;")
+    
+    // Script tag can have empty children
+    if (html) {
+      // we need to preserve quote inside style declaration
+      if (tag !== 'style') {
+        html = html.replace(/"/g, '&quot;');
+      }
+      props.dangerouslySetInnerHTML = { __html: html.trim() };
     }
-    props.dangerouslySetInnerHTML = { __html: html.trim() };
+    
     return customElement
       ? React.createElement(customElement as any, props, null)
       : defaultTransform

--- a/src/server.ts
+++ b/src/server.ts
@@ -48,10 +48,17 @@ function transform(node: Node, key: string, options: HtmrOptions): ReactNode {
 
       // if the tags children should be set dangerously
       if (options.dangerouslySetChildren.indexOf(name) > -1) {
-        const childNode = <TextNode>node.children[0];
-        props.dangerouslySetInnerHTML = {
-          __html: childNode.data.trim()
-        };
+        
+        // Script tag can have empty children
+        if (node.children.length > 0) {
+          const childNode = <TextNode>(
+            node.children[0]
+          );
+          props.dangerouslySetInnerHTML = {
+            __html: childNode.data.trim(),
+          };
+        }
+        
         return customElement
           ? React.createElement(customElement as any, props, null)
           : defaultTransform

--- a/test/__snapshots__/convert.test.js.snap
+++ b/test/__snapshots__/convert.test.js.snap
@@ -82,6 +82,12 @@ exports[`custom component 1`] = `
 </p>
 `;
 
+exports[`dangerously render empty script tag 1`] = `
+<script
+  type="text/javascript"
+/>
+`;
+
 exports[`dangerously render script tag 1`] = `
 <script
   data-cfasync="false"

--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -264,6 +264,12 @@ test('dangerously render script tag', () => {
   testRender(html);
 });
 
+test('dangerously render empty script tag', () => {
+  const html = `<script type="text/javascript"></script>`.trim();
+
+  testRender(html, { dangerouslySetChildren: ['script'] });
+});
+
 test('svg viewbox', () => {
   const svg = `<svg viewbox="0 0 24 24"></svg>`
 


### PR DESCRIPTION
When setting `dangerouslySetChildren` for script tag and there are some empty script tag, current implementation will throw error.