### PR TITLE
Use type-only import for better verbatimModuleSyntax support

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,10 @@
-import type {
-  ReactHTML,
-  ReactSVG,
-  ReactNode,
-  ComponentType,
-  ComponentProps,
-  AllHTMLAttributes,
+import {
+  type ReactHTML,
+  type ReactSVG,
+  type ReactNode,
+  type ComponentType,
+  type ComponentProps,
+  type AllHTMLAttributes,
 } from 'react';
 
 export type HTMLTags = keyof ReactHTML;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ReactHTML,
   ReactSVG,
   ReactNode,


### PR DESCRIPTION
Hi, I have this weird TypeScript issue where—even though I have excluded `node_modules` in my `tsconfig.json`—I get a type error from "htmr" when using `tsc`.

I'm using `verbatimModuleSyntax` ([documentation](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax)) to simplify import elision. The setting comes down to ensuring you use the `type` modifier when importing types. So I did that in `src/types.ts`.

I don't think it'd have any negative impact since `yarn typecheck` ran successfully. But feel free to let me know otherwise.

Thanks for considering!